### PR TITLE
Fix feeding creation endpoint

### DIFF
--- a/dotnet/CatScale.UI.BlazorServer/Services/CatScaleService.cs
+++ b/dotnet/CatScale.UI.BlazorServer/Services/CatScaleService.cs
@@ -278,7 +278,7 @@ public class CatScaleService : ICatScaleService
     public async Task<FeedingDto> CreateFeeding(int catId, int foodId, DateTimeOffset timestamp, double offered,
         double eaten)
     {
-        var response = (await _httpClient.PutAsJsonAsync("api/Cat/Create",
+        var response = (await _httpClient.PutAsJsonAsync("api/Feeding/Create",
                 new CreateFeedingRequest(catId, foodId, timestamp, offered, eaten)))
             .EnsureSuccessStatusCode();
 


### PR DESCRIPTION
## Summary
- correct the API endpoint used by the Blazor front-end when creating a feeding

## Testing
- `dotnet test dotnet/CatScale.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be14f828483259a175de7d872aa3b